### PR TITLE
Fixed windows build

### DIFF
--- a/core_interface.cpp
+++ b/core_interface.cpp
@@ -7,7 +7,7 @@ namespace YGOpen
 
 //TODO: Use a DEFINE macro on premake instead, and fallback to these values
 #ifdef _WIN32
-static const char* DEFAULT_CORE_NAME = "ocgcore.dll";
+static const char* DEFAULT_CORE_NAME = "ygopen-core.dll";
 #else
 static const char* DEFAULT_CORE_NAME = "./libygopen-core.so";
 #endif
@@ -39,7 +39,7 @@ void* NativeLoadObject(const char* file)
 		files.  LoadLibrary() is a private API, and not available for apps
 		(that can be published to MS' Windows Store.)
 	*/
-	void* handle = (void*) LoadPackagedLibrary(tstr, 0);
+	void* handle = (void*) LoadPackagedLibrary(file, 0);
 #else
 	void* handle = (void*)LoadLibrary(file);
 #endif
@@ -126,11 +126,11 @@ T CoreInterface::LoadFunction(void* handle, T* func, const char* name, bool unlo
 	return *func;
 }
 
-CoreInterface::CoreInterface(bool loadlibrary) :
+CoreInterface::CoreInterface(bool loadCore) :
 	activeCorePath(""),
 	handle(nullptr)
 {
-	if(loadlibrary)
+	if(loadCore)
 		LoadCore();
 }
 

--- a/core_interface.hpp
+++ b/core_interface.hpp
@@ -20,10 +20,10 @@ class CoreInterface
 	T LoadFunction(void* handle, T* func, const char* name, bool unload);
 public:
 	// Core loading
-	CoreInterface(bool loadLibrary);
-	bool LoadLibrary(const char* path);
-	bool LoadLibrary();
-	bool ReloadLibrary();
+	CoreInterface(bool Loadlibrary);
+	bool LoadCore(const char* path);
+	bool LoadCore();
+	bool ReloadCore();
 
 	bool IsLibraryLoaded();
 
@@ -56,7 +56,7 @@ public:
 
 	// Core unloading
 	~CoreInterface();
-	void UnloadLibrary(); 
+	void UnloadCore(); 
 };
 
 } // namespace YGOpen

--- a/premake4.lua
+++ b/premake4.lua
@@ -1,9 +1,19 @@
+local sqlite_dir = "../sqlite3"
+local json_dir = "../json-develop/include"
+
 project("ygopen")
 	kind("StaticLib")
 	flags("ExtraWarnings")
 	files({"**.hpp", "**.cpp"})
 	links({"sqlite3"})
 
+	configuration "windows"
+		includedirs (sqlite_dir)
+		includedirs (json_dir)
+		defines { "WIN32", "_WIN32", "NOMINMAX" }
+		
+	configuration "vs*"
+		characterset("MBCS")
 	configuration("not windows")
 		buildoptions("-pedantic")
 		links("dl")


### PR DESCRIPTION
Changed the name of the LoadLibrary function (and the related ones) to LoadCore to fix the issue with the macro defined in windows' headers with the same name. Added "_WIN32" and "WIN32" defines directly in the premake as those are the defines used mostly in all the surce codes targetting windows. Updated premake scripts to properly create visual studio configurations.