### PR TITLE
Update premake for OS X build

### DIFF
--- a/duel.cpp
+++ b/duel.cpp
@@ -1,5 +1,7 @@
 #include <cassert>
 #include <cstdint>
+#include <cstring>
+#include <cstdlib>
 #include <map>
 
 #include "duel.hpp"

--- a/premake4.lua
+++ b/premake4.lua
@@ -1,19 +1,15 @@
-local sqlite_dir = "../sqlite3"
-local json_dir = "../json-develop/include"
+local json_dir     = "../json-develop/include"
 
 project("ygopen")
 	kind("StaticLib")
 	flags("ExtraWarnings")
 	files({"**.hpp", "**.cpp"})
 	links({"sqlite3"})
+	includedirs(json_dir)
 
-	configuration "windows"
-		includedirs (sqlite_dir)
-		includedirs (json_dir)
-		defines { "WIN32", "_WIN32", "NOMINMAX" }
-		
-	configuration "vs*"
-		characterset("MBCS")
+	configuration("osx")
+		buildoptions("-pedantic --std=c++11")
+		links("dl")
 	configuration("not windows")
 		buildoptions("-pedantic")
 		links("dl")


### PR DESCRIPTION
Based off version of `premake4.lua` **before** #1, as per discussion in Discord @edo9300  seemingly broke things. Sorry, you'll have to reconcile the differences. This is tested and compiles with DyXel/ygopen-srv/pull/2 on my OS X machine, with `asio and `sqlite3` installed via homebrew and `json-develop` in a parent folder as per the path listed in `premake4.lua`. I'm not 100% sure what I'm doing with premake files, lol, so hopefully this is correct and stuff.