### PR TITLE
YGOpen::Bit::popcount: fix 64 bit specialization for gcc/clang compilers

### DIFF
--- a/include/ygopen/bit.hpp
+++ b/include/ygopen/bit.hpp
@@ -21,8 +21,8 @@ constexpr auto popcnt(T x) noexcept -> int
 #if defined(__cpp_lib_bitops)
 	return std::popcount(x);
 #elif defined(__GNUC__) || defined(__clang__)
-	if constexpr(std::is_same_v<unsigned long, T>)
-		return __builtin_popcountl(x);
+	if constexpr(std::numeric_limits<T>::digits > 32)
+		return __builtin_popcountll(x);
 	else
 		return __builtin_popcount(x);
 #else


### PR DESCRIPTION
Make it use `__builtin_popcountll` and not `__builtin_popcountl` if the passed value has a binary representation of more than 32 digits.
Properly handle the case of 32 bit *nux builds and MingW builds where `unsigned long` is actually 32 bits.