### PR TITLE
Server's Room implementation (WIP)

### DIFF
--- a/include/ygopen/detail/config.hpp
+++ b/include/ygopen/detail/config.hpp
@@ -23,4 +23,7 @@
 #endif // !defined(YGOPEN_DISABLE_CONCEPTS)
 #endif // !defined(YGOPEN_HAS_CONCEPTS)
 
+#define YGOPEN_TYPEOF(x) \
+	typename std::remove_cv_t<std::remove_reference_t<decltype(x)>>
+
 #endif // YGOPEN_DETAIL_CONFIG_HPP

--- a/include/ygopen/detail/config.hpp
+++ b/include/ygopen/detail/config.hpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024, Dylam De La Torre <dyxel04@gmail.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 #ifndef YGOPEN_DETAIL_CONFIG_HPP
 #define YGOPEN_DETAIL_CONFIG_HPP
 
@@ -6,5 +11,16 @@
 #else
 #define YGOPEN_UNREACHABLE() __builtin_unreachable()
 #endif // _MSC_VER
+
+#if !defined(YGOPEN_HAS_CONCEPTS)
+#if !defined(YGOPEN_DISABLE_CONCEPTS)
+#if defined(__cpp_concepts)
+#define YGOPEN_HAS_CONCEPTS 1
+#define YGOPEN_CONCEPT(x) x
+#else
+#define YGOPEN_CONCEPT(x) typename
+#endif // defined(__cpp_concepts)
+#endif // !defined(YGOPEN_DISABLE_CONCEPTS)
+#endif // !defined(YGOPEN_HAS_CONCEPTS)
 
 #endif // YGOPEN_DETAIL_CONFIG_HPP

--- a/include/ygopen/detail/config.hpp
+++ b/include/ygopen/detail/config.hpp
@@ -16,9 +16,9 @@
 #if !defined(YGOPEN_DISABLE_CONCEPTS)
 #if defined(__cpp_concepts)
 #define YGOPEN_HAS_CONCEPTS 1
-#define YGOPEN_CONCEPT(x) x
+#define YGOPEN_CONCEPT(x) x x
 #else
-#define YGOPEN_CONCEPT(x) typename
+#define YGOPEN_CONCEPT(x) typename x
 #endif // defined(__cpp_concepts)
 #endif // !defined(YGOPEN_DISABLE_CONCEPTS)
 #endif // !defined(YGOPEN_HAS_CONCEPTS)

--- a/include/ygopen/proto/deck.proto
+++ b/include/ygopen/proto/deck.proto
@@ -34,8 +34,6 @@ message Deck
 	string title            = 3; // Deck title.
 	string banlist_id       = 4; // Banlist ID where the deck should be used.
 	string notes            = 5; // Deck notes (guide, combos, etc.).
-
-	bool is_valid = 6; // FIXME: remove later.
 }
 
 message DeckLimits

--- a/include/ygopen/proto/deck.proto
+++ b/include/ygopen/proto/deck.proto
@@ -34,6 +34,8 @@ message Deck
 	string title            = 3; // Deck title.
 	string banlist_id       = 4; // Banlist ID where the deck should be used.
 	string notes            = 5; // Deck notes (guide, combos, etc.).
+
+	bool is_valid = 6; // FIXME: remove later.
 }
 
 message DeckLimits
@@ -41,7 +43,7 @@ message DeckLimits
 	message Limit
 	{
 		uint32 min = 1;
-		// NOTE: A negative number should be a implementation defined limit.
+		// NOTE: A negative number should be a implementation-defined limit.
 		int32 max = 2;
 	}
 	Limit main  = 1;

--- a/include/ygopen/proto/meson.build
+++ b/include/ygopen/proto/meson.build
@@ -15,6 +15,7 @@ ygopen_proto_src = files(
 	'duel_data.proto',
 	'duel_msg.proto',
 	'replay.proto',
+	'room.proto',
 	'user.proto',
 )
 

--- a/include/ygopen/proto/meson.build
+++ b/include/ygopen/proto/meson.build
@@ -10,12 +10,14 @@ protoc_gen = generator(protoc,
 
 ygopen_proto_src = files(
 	'banlist.proto',
+	'client_msg.proto',
 	'deck.proto',
 	'duel_answer.proto',
 	'duel_data.proto',
 	'duel_msg.proto',
 	'replay.proto',
 	'room.proto',
+	'server_msg.proto',
 	'user.proto',
 )
 

--- a/include/ygopen/proto/room.hpp
+++ b/include/ygopen/proto/room.hpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Dylam De La Torre <dyxel04@gmail.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifndef YGOPEN_PROTO_ROOM_HPP
+#define YGOPEN_PROTO_ROOM_HPP
+// clang-format off
+#include <room.pb.h>
+// clang-format on
+
+namespace YGOpen::Proto::Room
+{
+
+constexpr size_t MAX_DUELISTS_PER_TEAM = 3;
+
+} // namespace YGOpen::Proto::Room
+
+#endif // YGOPEN_PROTO_ROOM_HPP

--- a/include/ygopen/proto/room.proto
+++ b/include/ygopen/proto/room.proto
@@ -30,14 +30,14 @@ enum State
 
 enum FirstTurnDecideMethod
 {
-	// Rock paper scissors, winner decides.
-	FTDM_RPS = 0;
-	// Each team rolls a six-sided die, higher roll wins.
-	FTDM_DICE = 1;
-	// A coin is tossed: Heads == team0 wins, Tails == team1 wins.
-	FTDM_COIN = 2;
 	// Room's host chooses which team goes first directly.
-	FTDM_HOST_CHOOSES = 3;
+	FTDM_HOST_CHOOSES = 0;
+	// Rock paper scissors, winner decides.
+	FTDM_RPS = 1;
+	// Each team rolls a six-sided die, higher roll wins.
+	FTDM_DICE = 2;
+	// A coin is tossed: Heads == team0 wins, Tails == team1 wins.
+	FTDM_COIN = 3;
 }
 
 message Duelist
@@ -98,23 +98,48 @@ message Event
 	{
 		message EnteringState
 		{
-
+			// TODO: Do we really need this?
 		}
 
 		message Result
 		{
+			// From core and card textures:
+			// invalid = 0
+			// scissors = 1
+			// rock = 2
+			// paper = 3
+			// invalid = 4
 			message RPS {}  // TODO
-			message Dice {} // TODO
-			message Coin {} // TODO
+
+			message Dice
+			{
+				message ResultPair
+				{
+					// NOTE: Results are from 1 to 6 (so 1-indexed),
+					//       this matches the values from the core.
+					uint32 team0 = 1;
+					uint32 team1 = 2;
+				}
+
+				repeated ResultPair results = 1;
+			}
+
+			// TODO: These match values from the core, move them common place
+			//       between Duel and this.
+			enum CoinResult
+			{
+				COIN_RESULT_HEADS = 0; // team0
+				COIN_RESULT_TAILS = 1; // team1
+			}
 
 			// Either a team (0 or 1), any other value indicates a draw.
 			uint32 team_going_first = 1;
 
 			oneof t
 			{
-				RPS rps             = 2;
-				Dice dice           = 3;
-				Coin coin           = 4;
+				RPS rps                = 2;
+				Dice dice              = 3;
+				CoinResult coin_result = 4;
 			}
 		}
 

--- a/include/ygopen/proto/room.proto
+++ b/include/ygopen/proto/room.proto
@@ -22,6 +22,22 @@ enum State
 	// Main "Idle" state, where duelists can ready up and where the host can
 	// change settings among other things.
 	STATE_CONFIGURING = 1;
+	// State where team leaders can decide who goes first.
+	STATE_DECIDING_FIRST_TURN = 2;
+	// State during which duelists conduct a single duel.
+	STATE_DUELING = 3;
+}
+
+enum FirstTurnDecideMethod
+{
+	// Rock paper scissors, winner decides.
+	FTDM_RPS = 0;
+	// Each team rolls a six-sided die, higher roll wins.
+	FTDM_DICE = 1;
+	// A coin is tossed: Heads == team0 wins, Tails == team1 wins.
+	FTDM_COIN = 2;
+	// Room's host chooses which team goes first directly.
+	FTDM_HOST_CHOOSES = 3;
 }
 
 message Duelist
@@ -46,6 +62,8 @@ message Options
 		string banlist_id        = 3;
 		Banlist custom_banlist   = 4;
 	}
+
+	FirstTurnDecideMethod ftdm = 5;
 
 	// TODO: Duel options
 }
@@ -76,10 +94,57 @@ message Event
 		}
 	}
 
+	message DecidingFirstTurn
+	{
+		message EnteringState
+		{
+
+		}
+
+		message Result
+		{
+			message RPS {}  // TODO
+			message Dice {} // TODO
+			message Coin {} // TODO
+
+			// Either a team (0 or 1), any other value indicates a draw.
+			uint32 team_going_first = 1;
+
+			oneof t
+			{
+				RPS rps             = 2;
+				Dice dice           = 3;
+				Coin coin           = 4;
+			}
+		}
+
+		oneof t
+		{
+			EnteringState entering_state = 1;
+			bool decide_first_turn       = 2;
+			Result result                = 3;
+		}
+	}
+
+	message Dueling
+	{
+		message EnteringState
+		{
+			// TODO
+		}
+
+		oneof t
+		{
+			EnteringState entering_state = 1;
+		}
+	}
+
 	oneof t
 	{
-		Configuring configuring = 1;
-		uint32 spectator_count  = 2;
+		Configuring configuring               = 1;
+		DecidingFirstTurn deciding_first_turn = 2;
+		Dueling dueling                       = 3;
+		uint32 spectator_count                = 4;
 	}
 }
 
@@ -89,13 +154,24 @@ message Signal
 	{
 		oneof t
 		{
-			Deck update_deck  = 1;
-			bool ready_status = 2;
+			Deck update_deck   = 1;
+			bool ready_status  = 2;
+			bool start_dueling = 3;
+		}
+	}
+
+	message DecidingFirstTurn
+	{
+		oneof t
+		{
+			// TODO: RPS Choice
+			uint32 team_going_first = 1;
 		}
 	}
 
 	oneof t
 	{
-		Configuring configuring = 1;
+		Configuring configuring               = 1;
+		DecidingFirstTurn deciding_first_turn = 2;
 	}
 }

--- a/include/ygopen/proto/room.proto
+++ b/include/ygopen/proto/room.proto
@@ -18,7 +18,7 @@ option cc_enable_arenas = true;
 enum State
 {
 	// Transitive state, when the room is being constructed or closing.
-	STATE_HOSTING_CLOSING = 0;
+	STATE_MONOSTATE = 0;
 	// Main "Idle" state, where duelists can ready up and where the host can
 	// change settings among other things.
 	STATE_CONFIGURING = 1;

--- a/include/ygopen/proto/room.proto
+++ b/include/ygopen/proto/room.proto
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, Dylam De La Torre <dyxel04@gmail.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+syntax = "proto3";
+
+// TODO: Documentation
+
+package YGOpen.Proto.Room;
+
+import "banlist.proto";
+import "deck.proto";
+import "user.proto";
+
+option cc_enable_arenas = true;
+
+enum State
+{
+	// Transitive state, when the room is being constructed or closing.
+	STATE_HOSTING_CLOSING = 0;
+	// Main "Idle" state, where duelists can ready up and where the host can
+	// change settings among other things.
+	STATE_CONFIGURING = 1;
+}
+
+message Duelist
+{
+	uint32 team   = 1;
+	uint32 pos    = 2;
+	User user     = 3;
+	bool is_host  = 4;
+	bool is_ready = 5;
+}
+
+message Options
+{
+	// Minimum 1 duelist per team, must have exactly 2 values (one for each
+	// team). Values are clamped to minimum and implementation-defined maximum.
+	repeated uint32 max_duelists = 1;
+
+	DeckLimits deck_limits       = 2;
+
+	oneof banlist
+	{
+		string banlist_id        = 3;
+		Banlist custom_banlist   = 4;
+	}
+
+	// TODO: Duel options
+}
+
+message Event
+{
+	message Configuring
+	{
+		message EnteringState
+		{
+			Options options           = 1;
+			repeated Duelist duelists = 2;
+			uint32 spectator_count    = 3;
+			// TODO: Send room settings (don't remember what this means)
+		}
+
+		message DeckStatus
+		{
+			DeckError deck_error = 1;
+		}
+
+		oneof t
+		{
+			EnteringState entering_state = 1;
+			Duelist duelist_enters       = 2;
+			Duelist update_duelist       = 3;
+			DeckStatus deck_status       = 4;
+		}
+	}
+
+	oneof t
+	{
+		Configuring configuring = 1;
+		uint32 spectator_count  = 2;
+	}
+}
+
+message Signal
+{
+	message Configuring
+	{
+		oneof t
+		{
+			Deck update_deck  = 1;
+			bool ready_status = 2;
+		}
+	}
+
+	oneof t
+	{
+		Configuring configuring = 1;
+	}
+}

--- a/include/ygopen/server/room.hpp
+++ b/include/ygopen/server/room.hpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <google/protobuf/arena.h>
 #include <set>
+#include <utility>
 #include <ygopen/detail/config.hpp>
 #include <ygopen/proto/deck.hpp>
 #include <ygopen/proto/room.hpp>
@@ -63,10 +64,10 @@ public:
 
 	BasicRoom(DeckValidator const& deck_validator,
 	          CoreDuelFactory const& core_duel_factory, Client& host,
-	          YGOpen::Proto::Room::Options const& options) noexcept
+	          YGOpen::Proto::Room::Options options) noexcept
 		: deck_validator_(&deck_validator)
 		, core_duel_factory_(&core_duel_factory)
-		, options_(options)
+		, options_(std::move(options))
 		, state_(RoomState::STATE_HOSTING_CLOSING)
 		, host_(&host)
 		, teams_({})
@@ -359,7 +360,7 @@ private:
 		YGOpen::Proto::Deck deck;
 
 		constexpr DuelistSlot() noexcept
-			: deck_valid(false), ready(false), client(nullptr), deck()
+			: deck_valid(false), ready(false), client(nullptr)
 		{}
 	};
 

--- a/include/ygopen/server/room.hpp
+++ b/include/ygopen/server/room.hpp
@@ -266,8 +266,8 @@ public:
 					break;
 				if(new_status && !search.slot->deck_valid)
 				{
-					// TODO: Send message saying that you need a valid deck
-					// before readying up.
+					// TODO: Report that you need a valid deck before readying.
+					break;
 				}
 				search.slot->ready = new_status;
 				auto* e = event_();
@@ -366,22 +366,9 @@ private:
 			v = std::clamp<uint32_t>(v, 1, std::tuple_size_v<Team>);
 	}
 
-	auto exit_current_state_() noexcept -> void
-	{
-		switch(state_)
-		{
-		case RoomState::STATE_HOSTING_CLOSING:
-			break;
-		case RoomState::State_INT_MIN_SENTINEL_DO_NOT_USE_:
-		case RoomState::State_INT_MAX_SENTINEL_DO_NOT_USE_:
-			YGOPEN_UNREACHABLE();
-		}
-	}
-
 	auto enter_state_(RoomState new_state) noexcept -> void
 	{
 		assert(state_ != new_state);
-		exit_current_state_();
 		state_ = new_state;
 		switch(state_)
 		{

--- a/include/ygopen/server/room.hpp
+++ b/include/ygopen/server/room.hpp
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2024, Dylam De La Torre <dyxel04@gmail.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifndef YGOPEN_SERVER_ROOM_HPP
+#define YGOPEN_SERVER_ROOM_HPP
+#include <array>
+#include <google/protobuf/arena.h>
+#include <set>
+#include <ygopen/detail/config.hpp>
+#include <ygopen/proto/deck.hpp>
+#include <ygopen/proto/room.hpp>
+#include <ygopen/proto/user.hpp>
+
+namespace YGOpen::Server
+{
+
+using RoomState = YGOpen::Proto::Room::State;
+using RoomEvent = YGOpen::Proto::Room::Event;
+using RoomSignal = YGOpen::Proto::Room::Signal;
+
+template<typename Client, typename DeckValidator, typename CoreDuelFactory>
+#ifdef YGOPEN_HAS_CONCEPTS
+requires requires(Client& c, RoomEvent const& re, YGOpen::Proto::User& u)
+{
+	{
+		c.send(re)
+	} noexcept;
+	{
+		std::as_const(c).fill_user(u)
+	} noexcept;
+}
+&&requires(DeckValidator const& dv, std::string_view banlist_id,
+           YGOpen::Proto::Deck const& d, YGOpen::Proto::DeckError& de)
+{
+	{
+		dv.check(banlist_id, d, de)
+	} noexcept -> std::same_as<bool>;
+	// { // TODO: Check custom banlist?
+	// 	dv.check(b, d, de)
+	// } noexcept -> std::same_as<bool>;
+}
+&&requires(CoreDuelFactory const& cdf)
+{
+	{
+		cdf.make_duel(/*TODO*/)
+	} noexcept /*-> TODO*/;
+}
+#endif // YGOPEN_HAS_CONCEPTS
+class BasicRoom
+{
+public:
+	class InternalSignal;
+
+	BasicRoom(DeckValidator const& deck_validator,
+	          CoreDuelFactory const& core_duel_factory, Client& host,
+	          YGOpen::Proto::Room::Options const& options) noexcept
+		: deck_validator_(&deck_validator)
+		, core_duel_factory_(&core_duel_factory)
+		, options_(options)
+		, state_(RoomState::STATE_HOSTING_CLOSING)
+		, host_(&host)
+		, teams_({})
+	{
+		for(auto& t : teams_)
+			for(auto* d : t)
+				assert(d == nullptr);
+		clamp_options_();
+		enter_state_(RoomState::STATE_CONFIGURING);
+		enter(host);
+	}
+
+	// TODO: Construct room from composed teams and no host (matchmaking case)
+
+	~BasicRoom() noexcept = default;
+	BasicRoom(BasicRoom&) = delete;
+	BasicRoom(BasicRoom const&) = delete;
+	BasicRoom(BasicRoom&&) = delete;
+	auto operator=(BasicRoom const&) -> BasicRoom& = delete;
+	auto operator=(BasicRoom&&) -> BasicRoom& = delete;
+
+	auto enter(Client& peer) noexcept -> void
+	{
+		struct Slot
+		{
+			uint8_t team = 0;
+			uint8_t pos = 0;
+		};
+		auto search_empty_duelist_slot = [&]() noexcept -> std::optional<Slot>
+		{
+			auto const& max_duelists = options_.max_duelists();
+			std::array<uint8_t, 2> duelist_count{0, 0};
+			std::array<int8_t, 2> first_empty_pos{-1, -1};
+			Slot slot;
+			for(auto const& t : teams_)
+			{
+				for(auto const* d : t)
+				{
+					if(d != nullptr)
+						duelist_count[slot.team]++;
+					else if(first_empty_pos[slot.team] < 0)
+						first_empty_pos[slot.team] = slot.pos;
+					if(++slot.pos == max_duelists[slot.team])
+						break;
+				}
+				slot.team++;
+				slot.pos = 0;
+			}
+			if(first_empty_pos[0] < 0 && first_empty_pos[1] < 0)
+				return std::nullopt;
+			if((duelist_count[0] <= duelist_count[1] &&
+			    !(first_empty_pos[0] < 0)) ||
+			   first_empty_pos[1] < 0)
+			{
+				assert(!(first_empty_pos[0] < 0));
+				slot.team = 0;
+				slot.pos = static_cast<uint8_t>(first_empty_pos[0]);
+			}
+			else
+			{
+				assert(!(first_empty_pos[1] < 0));
+				slot.team = 1;
+				slot.pos = static_cast<uint8_t>(first_empty_pos[1]);
+			}
+			return slot;
+		};
+		switch(state_)
+		{
+		case RoomState::STATE_CONFIGURING:
+		{
+			auto* e = event_();
+			auto* es = e->mutable_configuring()->mutable_entering_state();
+			*es->mutable_options() = options_;
+			{
+				Slot slot;
+				for(auto const& t : teams_)
+				{
+					for(auto const* d : t)
+					{
+						if(d != nullptr)
+						{
+							auto& duelist = *es->add_duelists();
+							duelist.set_team(slot.team);
+							duelist.set_pos(slot.pos);
+							d->fill_user(*duelist.mutable_user());
+							duelist.set_is_host(d == host_);
+							duelist.set_is_ready(
+								ready_statuses_[slot.team][slot.pos]);
+						}
+						slot.pos++;
+					}
+					slot.team++;
+				}
+			}
+			es->set_spectator_count(spectators_.size());
+			peer.send(*e);
+			auto const slot = search_empty_duelist_slot();
+			auto* e2 = event_();
+			if(slot.has_value())
+			{
+				teams_[slot->team][slot->pos] = &peer;
+				auto* msg = e2->mutable_configuring()->mutable_duelist_enters();
+				msg->set_team(slot->team);
+				msg->set_pos(slot->pos);
+				peer.fill_user(*msg->mutable_user());
+				msg->set_is_host(host_ == &peer);
+				msg->set_is_ready(false);
+			}
+			else
+			{
+				// NOTE: You can't become a host while initially joining as
+				//       spectator, but you can be a host that changes to it.
+				assert(host_ != &peer);
+				spectators_.insert(&peer);
+				e2->set_spectator_count(spectators_.size());
+			}
+			send_all_(*e2);
+			break;
+		}
+		case RoomState::STATE_HOSTING_CLOSING:
+			break;
+		case RoomState::State_INT_MIN_SENTINEL_DO_NOT_USE_:
+		case RoomState::State_INT_MAX_SENTINEL_DO_NOT_USE_:
+			YGOPEN_UNREACHABLE();
+		}
+	}
+
+	auto visit(InternalSignal const& signal) noexcept -> void;
+
+	auto visit(Client& peer, RoomSignal const& signal) noexcept -> void
+	{
+		auto const& max_duelists = options_.max_duelists();
+		struct Slot
+		{
+			uint8_t team = 0;
+			uint8_t pos = 0;
+		};
+		auto search_peer_duelist_slot = [&]() noexcept -> std::optional<Slot>
+		{
+			Slot slot;
+			for(auto const& t : teams_)
+			{
+				for(auto const* d : t)
+				{
+					if(d == &peer)
+						return slot;
+					if(++slot.pos == max_duelists[slot.team])
+						break;
+				}
+				slot.team++;
+				slot.pos = 0;
+			}
+			return std::nullopt;
+		};
+		auto const signal_case = signal.t_case();
+		switch(state_)
+		{
+		case RoomState::STATE_CONFIGURING:
+		{
+			if(signal_case != RoomSignal::kConfiguring)
+				break;
+			auto const& s = signal.configuring();
+			switch(s.t_case())
+			{
+			case RoomSignal::Configuring::kUpdateDeck:
+			{
+				auto const slot = search_peer_duelist_slot();
+				if(!slot.has_value())
+					break;
+				auto const& deck = s.update_deck();
+				auto* e = event_();
+				auto* ds = e->mutable_configuring()->mutable_deck_status();
+				auto* de = ds->mutable_deck_error();
+				// TODO: Handle custom banlist.
+				if(deck_validator_->check(options_.banlist_id(), deck, *de))
+				{
+					ds->clear_deck_error();
+					auto& stored_deck = duelist_decks_[slot->team][slot->pos];
+					stored_deck = deck;
+					stored_deck.set_is_valid(true);
+				}
+				else
+				{
+					duelist_decks_[slot->team][slot->pos] = {};
+				}
+				peer.send(*e);
+				break;
+			}
+			case RoomSignal::Configuring::kReadyStatus:
+			{
+				auto const slot = search_peer_duelist_slot();
+				if(!slot.has_value())
+					break;
+				bool const new_status = s.ready_status();
+				auto& current_status = ready_statuses_[slot->team][slot->pos];
+				if(new_status == current_status)
+					break;
+				// TODO: Check deck validation.
+				current_status = new_status;
+				auto* e = event_();
+				auto* msg = e->mutable_configuring()->mutable_update_duelist();
+				msg->set_team(slot->team);
+				msg->set_pos(slot->pos);
+				peer.fill_user(*msg->mutable_user());
+				msg->set_is_host(host_ == &peer);
+				msg->set_is_ready(new_status);
+				send_all_(*e);
+				break;
+			}
+			case RoomSignal::Configuring::T_NOT_SET:
+				break;
+			}
+			break;
+		}
+		case RoomState::State_INT_MIN_SENTINEL_DO_NOT_USE_:
+		case RoomState::State_INT_MAX_SENTINEL_DO_NOT_USE_:
+			YGOPEN_UNREACHABLE();
+		}
+	}
+
+private:
+	template<typename T>
+	using Team = std::array<T, YGOpen::Proto::Room::MAX_DUELISTS_PER_TEAM>;
+
+	template<typename T>
+	using Teams = std::array<Team<T>, 2>;
+
+	DeckValidator const* deck_validator_;
+	CoreDuelFactory const* core_duel_factory_;
+	YGOpen::Proto::Room::Options options_;
+	RoomState state_;
+
+	Client const* host_;
+	Teams<Client*> teams_;
+	std::set<Client*> spectators_;
+
+	google::protobuf::Arena arena_;
+
+	// Used by at least CONFIGURING and DUELING state.
+	Teams<YGOpen::Proto::Deck> duelist_decks_;
+
+	// CONFIGURING STATE'S STATE
+	Teams<bool> ready_statuses_;
+
+	auto event_() noexcept -> RoomEvent*
+	{
+		auto* re = google::protobuf::Arena::CreateMessage<RoomEvent>(&arena_);
+		assert(re != nullptr);
+		return re;
+	}
+
+	auto send_team_(uint8_t team, RoomEvent const& event) noexcept -> void
+	{
+		assert(event.t_case() != 0);
+		assert(team < teams_.size());
+		for(auto* d : teams_[team])
+			if(d != nullptr)
+				d->send(event);
+	}
+
+	auto send_spectators_(RoomEvent const& event) noexcept -> void
+	{
+		assert(event.t_case() != 0);
+		for(auto* s : spectators_)
+			s->send(event);
+	}
+
+	auto send_all_(RoomEvent const& event) noexcept -> void
+	{
+		assert(event.t_case() != 0);
+		send_team_(0, event);
+		send_team_(1, event);
+		send_spectators_(event);
+	}
+
+	auto clamp_options_() noexcept -> void
+	{
+		auto& max_duelists = *options_.mutable_max_duelists();
+		max_duelists.Resize(teams_.size(), 1);
+		for(auto& v : max_duelists)
+			v = std::clamp<uint32_t>(v, 1, std::tuple_size_v<Team<Client*>>);
+	}
+
+	auto exit_current_state_() noexcept -> void
+	{
+		switch(state_)
+		{
+		case RoomState::STATE_HOSTING_CLOSING:
+			break;
+		case RoomState::State_INT_MIN_SENTINEL_DO_NOT_USE_:
+		case RoomState::State_INT_MAX_SENTINEL_DO_NOT_USE_:
+			YGOPEN_UNREACHABLE();
+		}
+	}
+
+	auto enter_state_(RoomState new_state) noexcept -> void
+	{
+		assert(state_ != new_state);
+		exit_current_state_();
+		state_ = new_state;
+		switch(state_)
+		{
+		case RoomState::STATE_CONFIGURING:
+		{
+			// TODO: If we came from matchmake case:
+			//         * Decide a new host.
+			//         * Re-check Client decks.
+			ready_statuses_ = {};
+			auto* e = event_();
+			e->mutable_configuring()->mutable_entering_state();
+			send_all_(*e);
+			break;
+		}
+		case RoomState::State_INT_MIN_SENTINEL_DO_NOT_USE_:
+		case RoomState::State_INT_MAX_SENTINEL_DO_NOT_USE_:
+			YGOPEN_UNREACHABLE();
+		}
+	}
+};
+
+} // namespace YGOpen::Server
+
+#endif // YGOPEN_SERVER_ROOM_HPP

--- a/include/ygopen/server/room.hpp
+++ b/include/ygopen/server/room.hpp
@@ -229,7 +229,7 @@ private:
 	auto enter_state_(Args&&... args) noexcept -> void
 	{
 		auto const old_state_idx = states_.index();
-		auto state = states_.template emplace<T>(std::forward<Args>(args)...);
+		auto& state = states_.template emplace<T>(std::forward<Args>(args)...);
 		auto const new_state_idx = states_.index();
 		assert(old_state_idx != new_state_idx);
 		on_enter_state_(state);
@@ -464,9 +464,10 @@ private:
 			}
 			return search;
 		};
+		using SignalCases = YGOPEN_TYPEOF(signal)::TCase;
 		switch(signal.t_case())
 		{
-		case RoomSignal::Configuring::kUpdateDeck:
+		case SignalCases::kUpdateDeck:
 		{
 			auto const search = find_peer_duelist_slot();
 			if(search.slot == nullptr)
@@ -490,7 +491,7 @@ private:
 			peer.send(*e);
 			break;
 		}
-		case RoomSignal::Configuring::kReadyStatus:
+		case SignalCases::kReadyStatus:
 		{
 			auto const search = find_peer_duelist_slot();
 			if(search.slot == nullptr)
@@ -514,7 +515,7 @@ private:
 			send_all_(*e);
 			break;
 		}
-		case RoomSignal::Configuring::kStartDueling:
+		case SignalCases::kStartDueling:
 		{
 			if(&peer != host_)
 				break;
@@ -545,7 +546,7 @@ private:
 			enter_state_<DecidingFirstTurn>();
 			break;
 		}
-		case RoomSignal::Configuring::T_NOT_SET:
+		case SignalCases::T_NOT_SET:
 			break;
 		}
 	}
@@ -554,10 +555,12 @@ private:
 		DecidingFirstTurn& state, ClientType& peer,
 		YGOPEN_TYPEOF(state)::SignalType const& signal) noexcept -> void
 	{
+		// TODO: Setup timeouts
 		using FTDM = YGOpen::Proto::Room::FirstTurnDecideMethod;
+		using SignalCases = YGOPEN_TYPEOF(signal)::TCase;
 		switch(signal.t_case())
 		{
-		case RoomSignal::DecidingFirstTurn::kTeamGoingFirst:
+		case SignalCases::kTeamGoingFirst:
 		{
 			if(options_.ftdm() != FTDM::FTDM_HOST_CHOOSES || &peer != host_)
 				break;
@@ -572,8 +575,7 @@ private:
 			// TODO: enter_state_(RoomState::STATE_DUELING);
 			break;
 		}
-		// TODO: Timeout signal
-		case RoomSignal::DecidingFirstTurn::T_NOT_SET:
+		case SignalCases::T_NOT_SET:
 			break;
 		}
 	}

--- a/include/ygopen/server/room.hpp
+++ b/include/ygopen/server/room.hpp
@@ -54,9 +54,8 @@ concept CoreDuelFactory = requires(T cdf)
 };
 #endif // YGOPEN_HAS_CONCEPTS
 
-template<YGOPEN_CONCEPT(Client) Client,
-         YGOPEN_CONCEPT(DeckValidator) DeckValidator,
-         YGOPEN_CONCEPT(CoreDuelFactory) CoreDuelFactory>
+template<YGOPEN_CONCEPT(Client), YGOPEN_CONCEPT(DeckValidator),
+         YGOPEN_CONCEPT(CoreDuelFactory)>
 class BasicRoom
 {
 public:

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,7 @@ ygopen_unit_tests_src = files(
 	'test/deck.cpp',
 	'test/frame.cpp',
 	'test/place.cpp',
+	'test/room.cpp',
 	'test/sequential_wrapper.cpp',
 	'test/value_wrappers.cpp',
 )

--- a/test/room.cpp
+++ b/test/room.cpp
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2024, Dylam De La Torre <dyxel04@gmail.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#include <functional>
+#include <gtest/gtest.h>
+#include <string_view>
+#include <tuple>
+#include <vector>
+#include <ygopen/server/room.hpp>
+
+namespace
+{
+
+using Ev = YGOpen::Server::RoomEvent;
+using EvRef = Ev const&;
+
+// using EvCase = YGOpen::Server::RoomEvent::Tcase; // TODO.
+
+// auto wrap(Client& clients...) -> clients... // TODO
+
+using Sig = YGOpen::Server::RoomSignal;
+
+class Client
+{
+public:
+	using Expectation = std::function<void(EvRef)>;
+
+	Client(std::string_view name = "Client") noexcept
+	{
+		user_.set_name(name.data(), name.size());
+	}
+
+	auto send(EvRef e) noexcept -> void { events_received_.push_back(e); }
+
+	auto fill_user(YGOpen::Proto::User& user) const noexcept { user = user_; }
+
+	auto expect(Expectation f) noexcept -> void { expectations_.push_back(f); }
+
+	auto expect(decltype(std::ignore)) noexcept -> void
+	{
+		expectations_.push_back([](EvRef) {});
+	}
+
+	~Client()
+	{
+		SCOPED_TRACE("For " + user_.name());
+		EXPECT_EQ(events_received_.size(), expectations_.size());
+		if(events_received_.empty())
+			return;
+		size_t i = 0;
+		for(auto& f : expectations_)
+		{
+			f(events_received_[i]);
+			// Lets try to run as many expectations as possible.
+			if(++i == events_received_.size())
+				return;
+		}
+	}
+
+private:
+	YGOpen::Proto::User user_;
+	std::vector<Ev> events_received_;
+	std::vector<Expectation> expectations_;
+};
+
+class DeckValidator
+{
+public:
+	DeckValidator(bool check_status = true) : check_status_(check_status) {}
+
+	auto check(std::string_view banlist_id, YGOpen::Proto::Deck const& deck,
+	           YGOpen::Proto::DeckError& error) const noexcept -> bool
+	{
+		return check_status_;
+	}
+
+private:
+	bool check_status_;
+} dv;
+
+class CoreDuelFactory
+{
+public:
+	auto make_duel(/*TODO*/) const noexcept -> void {}
+} cdf;
+
+using TestRoom =
+	YGOpen::Server::BasicRoom<Client, DeckValidator, CoreDuelFactory>;
+
+TEST(ServerRoom, ConstructionWithHostWorks)
+{
+	Client c;
+	c.expect(
+		[](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_entering_state());
+			ASSERT_TRUE(e.configuring().entering_state().has_options());
+		});
+	c.expect(
+		[](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_duelist_enters());
+			auto& de = e.configuring().duelist_enters();
+			EXPECT_EQ(de.team(), 0);
+			EXPECT_EQ(de.pos(), 0);
+			EXPECT_TRUE(de.is_host());
+		});
+	auto room = TestRoom{dv, cdf, c, {}};
+}
+
+TEST(ServerRoom, ConstructionOptionsClampingWorks)
+{
+	Client c;
+	YGOpen::Proto::Room::Options options;
+	options.add_max_duelists(99);
+	// NOTE: Only setting one on purpose, to test that the room fills the
+	//       missing value for the second team.
+	c.expect(
+		[](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_entering_state());
+			ASSERT_TRUE(e.configuring().entering_state().has_options());
+			auto& opts = e.configuring().entering_state().options();
+			EXPECT_EQ(opts.max_duelists_size(), 2);
+			EXPECT_EQ(opts.max_duelists(0), 3);
+			EXPECT_EQ(opts.max_duelists(1), 1);
+		});
+	c.expect(std::ignore);
+	auto room = TestRoom{dv, cdf, c, options};
+}
+
+TEST(ServerRoom, ConfiguringStateJoining1V1Works)
+{
+	YGOpen::Proto::Room::Options options;
+	options.add_max_duelists(1);
+	options.add_max_duelists(1);
+	Client c1("Client1");
+	c1.expect(std::ignore);
+	c1.expect(std::ignore);
+	auto room = TestRoom{dv, cdf, c1, options};
+	Client c2("Client2");
+	c2.expect(
+		[](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_entering_state());
+			ASSERT_TRUE(e.configuring().entering_state().has_options());
+			auto& ds = e.configuring().entering_state().duelists();
+			ASSERT_EQ(ds.size(), 1);
+			auto& d = ds[0];
+			EXPECT_EQ(d.team(), 0);
+			EXPECT_EQ(d.pos(), 0);
+			EXPECT_TRUE(d.has_user());
+			EXPECT_EQ(d.user().name(), "Client1");
+			EXPECT_TRUE(d.is_host());
+		});
+	auto exp = [](EvRef e)
+	{
+		ASSERT_TRUE(e.has_configuring());
+		ASSERT_TRUE(e.configuring().has_duelist_enters());
+		auto& de = e.configuring().duelist_enters();
+		EXPECT_EQ(de.team(), 1);
+		EXPECT_EQ(de.pos(), 0);
+		EXPECT_EQ(de.user().name(), "Client2");
+		EXPECT_FALSE(de.is_host());
+	};
+	c2.expect(exp);
+	c1.expect(exp);
+	room.enter(c2);
+}
+
+TEST(ServerRoom, ConfiguringStateJoining3V3Works)
+{
+	YGOpen::Proto::Room::Options options;
+	options.add_max_duelists(3);
+	options.add_max_duelists(3);
+	Client c1("Client1");
+	c1.expect(std::ignore);
+	c1.expect(std::ignore);
+	auto room = TestRoom{dv, cdf, c1, options};
+	int team = 1, pos = 0;
+	std::vector<Client> clients;
+	clients.reserve(5);
+	for(int i = 0; i < 5; i++)
+	{
+		auto const name = "Client" + std::to_string(i + 2);
+		auto& c = clients.emplace_back(name);
+		c.expect(std::ignore);
+		auto duelist_enters_expect = [team, pos, name](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_duelist_enters());
+			auto& de = e.configuring().duelist_enters();
+			EXPECT_EQ(de.team(), team);
+			EXPECT_EQ(de.pos(), pos);
+			EXPECT_EQ(de.user().name(), name);
+			EXPECT_FALSE(de.is_host());
+		};
+		c1.expect(duelist_enters_expect);
+		for(auto& c : clients)
+			c.expect(duelist_enters_expect);
+		if(team == 1)
+		{
+			team = 0;
+			pos++;
+		}
+		else
+		{
+			team++;
+		}
+		room.enter(c);
+	}
+}
+
+TEST(ServerRoom, ConfiguringStateJoiningFullWorks)
+{
+	YGOpen::Proto::Room::Options options;
+	options.add_max_duelists(1);
+	options.add_max_duelists(1);
+	Client c1("Client1");
+	c1.expect(std::ignore);
+	c1.expect(std::ignore);
+	auto room = TestRoom{dv, cdf, c1, options};
+	c1.expect(std::ignore);
+	Client c2("Client2");
+	c2.expect(std::ignore);
+	c2.expect(std::ignore);
+	room.enter(c2);
+	Client c3("Client3");
+	c3.expect(std::ignore);
+	auto exp1 = [](EvRef e)
+	{
+		ASSERT_TRUE(e.has_spectator_count());
+		ASSERT_EQ(e.spectator_count(), 1);
+	};
+	c1.expect(exp1);
+	c2.expect(exp1);
+	c3.expect(exp1);
+	room.enter(c3);
+	Client c4("Client4");
+	c4.expect(std::ignore);
+	auto exp2 = [](EvRef e)
+	{
+		ASSERT_TRUE(e.has_spectator_count());
+		ASSERT_EQ(e.spectator_count(), 2);
+	};
+	c1.expect(exp2);
+	c2.expect(exp2);
+	c3.expect(exp2);
+	c4.expect(exp2);
+	room.enter(c4);
+}
+
+TEST(ServerRoom, ConfiguringUpdatingInvalidDeckWorks)
+{
+	DeckValidator falsy_dv(false);
+	Client c;
+	c.expect(std::ignore);
+	c.expect(std::ignore);
+	auto room = TestRoom{falsy_dv, cdf, c, {}};
+	Sig s1;
+	s1.mutable_configuring()->mutable_update_deck();
+	room.visit(c, s1);
+	c.expect(
+		[](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_deck_status());
+			EXPECT_TRUE(e.configuring().deck_status().has_deck_error());
+		});
+}
+
+TEST(ServerRoom, ConfiguringUpdatingValidDeckWorks)
+{
+	Client c;
+	c.expect(std::ignore);
+	c.expect(std::ignore);
+	auto room = TestRoom{dv, cdf, c, {}};
+	Sig s1;
+	s1.mutable_configuring()->mutable_update_deck();
+	room.visit(c, s1);
+	c.expect(
+		[](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_deck_status());
+			EXPECT_FALSE(e.configuring().deck_status().has_deck_error());
+		});
+}
+
+TEST(ServerRoom, ConfiguringReadyingWithValidDeckWorks)
+{
+	Client c;
+	c.expect(std::ignore);
+	c.expect(std::ignore);
+	auto room = TestRoom{dv, cdf, c, {}};
+	Sig s1;
+	s1.mutable_configuring()->mutable_update_deck();
+	room.visit(c, s1);
+	c.expect(std::ignore);
+	Sig s2;
+	// Becoming ready
+	s2.mutable_configuring()->set_ready_status(true);
+	room.visit(c, s2);
+	c.expect(
+		[](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_update_duelist());
+			auto& ud = e.configuring().update_duelist();
+			EXPECT_EQ(ud.team(), 0);
+			EXPECT_EQ(ud.pos(), 0);
+			EXPECT_TRUE(ud.is_ready());
+		});
+	// Becoming not-ready
+	s2.mutable_configuring()->set_ready_status(false);
+	room.visit(c, s2);
+	c.expect(
+		[](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_update_duelist());
+			auto& ud = e.configuring().update_duelist();
+			EXPECT_FALSE(ud.is_ready());
+		});
+}
+
+TEST(ServerRoom, ConfiguringNonHostReadyingWorks)
+{
+	Client c1("Client1");
+	c1.expect(std::ignore);
+	c1.expect(std::ignore);
+	auto room = TestRoom{dv, cdf, c1, {}};
+	Sig s1;
+	s1.mutable_configuring()->mutable_update_deck();
+	room.visit(c1, s1);
+	c1.expect(std::ignore);
+	Sig s2;
+	s2.mutable_configuring()->set_ready_status(true);
+	room.visit(c1, s2);
+	c1.expect(std::ignore);
+	Client c2("Client2");
+	room.enter(c2);
+	c2.expect(
+		[](EvRef e)
+		{
+			ASSERT_TRUE(e.has_configuring());
+			ASSERT_TRUE(e.configuring().has_entering_state());
+			ASSERT_TRUE(e.configuring().entering_state().has_options());
+			auto& ds = e.configuring().entering_state().duelists();
+			ASSERT_EQ(ds.size(), 1);
+			auto& d = ds[0];
+			EXPECT_EQ(d.team(), 0);
+			EXPECT_EQ(d.pos(), 0);
+			EXPECT_TRUE(d.has_user());
+			EXPECT_EQ(d.user().name(), "Client1");
+			EXPECT_TRUE(d.is_ready());
+		});
+	c1.expect(std::ignore);
+	c2.expect(std::ignore);
+	room.visit(c2, s1);
+	c2.expect(std::ignore);
+	room.visit(c2, s2);
+	auto exp = [](EvRef e)
+	{
+		ASSERT_TRUE(e.has_configuring());
+		ASSERT_TRUE(e.configuring().has_update_duelist());
+		auto& ud = e.configuring().update_duelist();
+		EXPECT_TRUE(ud.has_user());
+		EXPECT_EQ(ud.user().name(), "Client2");
+		EXPECT_TRUE(ud.is_ready());
+	};
+	c1.expect(exp);
+	c2.expect(exp);
+}
+
+} // namespace

--- a/test/room.cpp
+++ b/test/room.cpp
@@ -141,8 +141,14 @@ public:
 	auto make_duel(/*TODO*/) const noexcept -> void {}
 } const cdf;
 
-using TestRoom =
-	YGOpen::Server::BasicRoom<Client, DeckValidator, CoreDuelFactory>;
+struct TestRoomTraits
+{
+	using ClientType = Client;
+	using DeckValidatorType = DeckValidator;
+	using CoreDuelFactoryType = CoreDuelFactory;
+};
+
+using TestRoom = YGOpen::Server::BasicRoom<TestRoomTraits>;
 
 TEST(ServerRoom, ConstructionWithHostWorks)
 {


### PR DESCRIPTION
Adds a generic implementation of a Server's Room to the library, it uses C++20 concepts to model the design, but the implementation is up to the users of the library (an example of a concrete Room type can be seen in the tests). The concepts are wrapped around macros and care has been taken to keep the library C++17-compatible, but developers can still benefit from the better diagnostics if they enable C++20. The concepts, even if not used, also serve as documentation.

This PR also adds the necessary messaging between clients and server, and the tests showcase how this communication happens by passing concrete protobuf classes around, asserting their contents.